### PR TITLE
Fix syntax error in profile database table rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -1363,11 +1363,6 @@ class MaterialCalculatorApp {
                 const weightValue = Number(profile && profile.Hmotnost_m);
                 const rowNumber = index + 1;
 
-            const rowsHTML = sortedProfiles.map((profile) => {
-                const type = profile && typeof profile.Typ === 'string' ? profile.Typ.trim() : '';
-                const dimensionValue = Number(profile && profile.Rozmer);
-                const weightValue = Number(profile && profile.Hmotnost_m);
-
                 const dimensionText = Number.isFinite(dimensionValue)
                     ? dimensionFormatter.format(dimensionValue)
                     : '–';
@@ -1377,9 +1372,7 @@ class MaterialCalculatorApp {
 
                 return `
                     <tr>
-
                         <td data-label="Pořadí" class="profile-database-index">${rowNumber}</td>
-
                         <td data-label="Typ">${this.escapeHTML(type)}</td>
                         <td data-label="Rozměr [mm]">${this.escapeHTML(dimensionText)}</td>
                         <td data-label="Hmotnost [kg/m]">${this.escapeHTML(weightText)}</td>


### PR DESCRIPTION
## Summary
- resolve a duplicate const declaration when rendering profile database rows to prevent a startup syntax error

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_b_68da8dc7ab1c8321b17dbe01763974dc