### PR TITLE
Fix export button initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -1888,7 +1888,10 @@ class MaterialCalculatorApp {
             return;
         }
 
-        const exportButtons = [
+        const exportButtons = Array.from(new Set([
+            ...(event && event.currentTarget ? [event.currentTarget] : []),
+            ...this.container.querySelectorAll('.profile-database-export')
+        ]));
 
         const setButtonsDisabled = (isDisabled) => {
             exportButtons.forEach((button) => {


### PR DESCRIPTION
## Summary
- fix the profile database export handler by collecting the buttons to disable before toggling their state
- prevent syntax errors during script parsing that previously blocked the page from loading

## Testing
- node -c script.js

------
https://chatgpt.com/codex/tasks/task_b_68dbf0f2d0288321b8e3b5ca90ee75cc