### PR TITLE
Fix home logo path to avoid missing asset request

### DIFF
--- a/script.js
+++ b/script.js
@@ -499,8 +499,8 @@ class MaterialCalculatorApp {
                     alt="TES logo"
                     class="app-logo"
                     decoding="async"
-                    data-logo-src="images/mainlogo.svg"
-                    data-logo-fallbacks="images/mainlogo.png, images/mainlogo.webp, images/mainlogo.jpg, images/mainlogo.jpeg"
+                    data-logo-src="images/mainlogo.png"
+                    data-logo-fallbacks="images/tes.webp"
                 >
             </figure>
         `;


### PR DESCRIPTION
## Summary
- point the home screen logo to the existing PNG asset and keep a valid fallback so the SPA no longer asks for a missing SVG

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_b_68dc03f83e348321b8c1bd11d3ef924a