### PR TITLE
Center profile database cells and restore overlay scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -722,6 +722,7 @@ main {
     border-radius: var(--radius-medium);
     border: 1px solid rgba(166, 206, 57, 0.28);
     overflow: auto;
+    min-height: 0;
     background: rgba(255, 255, 255, 0.98);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
     position: relative;
@@ -764,9 +765,13 @@ main {
 }
 
 
+.profile-database-table th,
+.profile-database-table td {
+    text-align: center;
+}
+
 .profile-database-table .profile-database-header-index,
 .profile-database-table .profile-database-index {
-    text-align: left;
     font-variant-numeric: tabular-nums;
     color: var(--color-muted);
 }
@@ -827,7 +832,8 @@ main {
 }
 
 .profile-database-cell {
-
+    display: block;
+    text-align: center;
     line-height: 1.35;
 }
 


### PR DESCRIPTION
## Summary
- center the profile database headers and data cells for consistent alignment
- allow the profile database table container to scroll within the dialog by preventing flex overflow issues

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_b_68dd0d5a44d4832196c0f482337ce4c0