### PR TITLE
Fix profile database modal scroll behaviour

### DIFF
--- a/style.css
+++ b/style.css
@@ -662,13 +662,15 @@ main {
     background: #ffffff;
     border-radius: var(--radius-large);
     width: min(960px, 100%);
-    max-height: min(90vh, 720px);
+    height: 90vh;
+    max-height: 720px;
     padding: clamp(1.5rem, 3vw, 2rem);
     box-shadow: var(--shadow-card);
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
     outline: none;
+    overflow: hidden;
 }
 
 .profile-database-header {
@@ -706,6 +708,8 @@ main {
     flex-direction: column;
     gap: 0.75rem;
     width: 100%;
+    flex: 1;
+    min-height: 0;
 }
 
 .profile-database-body {
@@ -714,6 +718,7 @@ main {
     width: 100%;
     margin: 0;
     min-height: 0;
+    overflow: hidden;
 }
 
 .profile-database-table {
@@ -726,6 +731,8 @@ main {
     background: rgba(255, 255, 255, 0.98);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
     position: relative;
+    height: 100%;
+    max-height: 100%;
 }
 
 .profile-database-table::after {
@@ -748,7 +755,7 @@ main {
 
 .profile-database-table col.profile-database-col-dimension,
 .profile-database-table col.profile-database-col-weight {
-
+    width: auto;
 }
 
 .profile-database-table thead th {
@@ -776,7 +783,7 @@ main {
     color: var(--color-muted);
 }
 
-
+.profile-database-table .profile-database-number {
     font-variant-numeric: tabular-nums;
     font-feature-settings: 'tnum' 1, 'lnum' 1;
 }
@@ -838,7 +845,6 @@ main {
 }
 
 .profile-database-cell--number {
-
     font-variant-numeric: tabular-nums;
     font-feature-settings: 'tnum' 1, 'lnum' 1;
 }


### PR DESCRIPTION
## Summary
- constrain the profile database dialog height and allow its content to flex so the database table stays within the viewport
- ensure the profile table container remains scrollable and keep numeric column formatting intact

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_b_68dd14a5b33c8321bd21ca8c3b58337a