### PR TITLE
Add hexagon weight calculator

### DIFF
--- a/images/sestihran.svg
+++ b/images/sestihran.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title id="title">Ikona šestihranu</title>
+  <desc id="desc">Jednoduchá geometrická ilustrace šestihranného profilu.</desc>
+  <defs>
+    <linearGradient id="hexGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#4c7dd1" />
+      <stop offset="100%" stop-color="#1b4f9c" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="16" ry="16" fill="#f1f5fb" />
+  <g transform="translate(10,10)">
+    <polygon points="50,5 90,28 90,72 50,95 10,72 10,28" fill="url(#hexGradient)" stroke="#163d73" stroke-width="4" stroke-linejoin="round" />
+    <line x1="50" y1="5" x2="50" y2="95" stroke="#ffffff" stroke-width="3" stroke-linecap="round" opacity="0.35" />
+    <line x1="10" y1="28" x2="90" y2="72" stroke="#ffffff" stroke-width="3" stroke-linecap="round" opacity="0.35" />
+    <line x1="90" y1="28" x2="10" y2="72" stroke="#ffffff" stroke-width="3" stroke-linecap="round" opacity="0.35" />
+  </g>
+</svg>

--- a/script.js
+++ b/script.js
@@ -36,6 +36,7 @@ const CALCULATOR_TILES = [
     { id: 'mezikruzi', title: 'Mezikruží', image: 'images/mezikruzi.png' },
     { id: 'trubka', title: 'Trubka', image: 'images/trubka.png' },
     { id: 'hranol', title: 'Hranol', image: 'images/hranol.png' },
+    { id: 'sestihran', title: 'Šestihran', image: 'images/sestihran.svg' },
     { id: 'valec', title: 'Válec', image: 'images/valec.png' },
     { id: 'jakl', title: 'Jakl', image: 'images/jakl.png' },
     { id: 'profil-l', title: 'Profil L', image: 'images/profil-l.png' },
@@ -148,6 +149,40 @@ const CALCULATORS = {
             }
 
             const area = width * height;
+            const volume = area * length;
+            const volumeM3 = volume / 1_000_000_000;
+
+            return {
+                value: volumeM3 * density
+            };
+        }
+    },
+    'sestihran': {
+        title: 'Šestihran',
+        resultLabel: 'Hmotnost:',
+        resultUnit: 'kg',
+        showMaterialSelector: true,
+        formula: `
+            <p><strong>Hmotnost</strong> = ρ × (\u221a3 ÷ 2 × S<sup>2</sup>) × L ÷ 10<sup>9</sup></p>
+            <p>ρ je hustota materiálu [kg/m<sup>3</sup>], S je šířka šestihranu [mm] a L je délka [mm].</p>
+        `,
+        inputs: [
+            { id: 'hex-width', label: 'Šířka S [mm]', type: 'number' },
+            { id: 'length', label: 'Délka L [mm]', type: 'number' }
+        ],
+        compute: (app) => {
+            const width = app.readNumber('hex-width');
+            const length = app.readNumber('length');
+            const density = app.getMaterialDensity();
+
+            if (width <= 0 || length <= 0) {
+                return {
+                    value: 0,
+                    error: 'Zadejte kladné hodnoty šířky i délky.'
+                };
+            }
+
+            const area = (Math.sqrt(3) / 2) * (width ** 2);
             const volume = area * length;
             const volumeM3 = volume / 1_000_000_000;
 


### PR DESCRIPTION
## Summary
- add menu tile and configuration for the hexagon weight calculator matching existing calculators
- include an SVG icon representing the hexagon profile for the home screen tile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68de4f1cb3d88321bb6096c41b039e38