### PR TITLE
Fix hexagon tile image reference

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,7 +36,7 @@ const CALCULATOR_TILES = [
     { id: 'mezikruzi', title: 'Mezikruží', image: 'images/mezikruzi.png' },
     { id: 'trubka', title: 'Trubka', image: 'images/trubka.png' },
     { id: 'hranol', title: 'Hranol', image: 'images/hranol.png' },
-    { id: 'sestihran', title: 'Šestihran', image: 'images/sestihran.svg' },
+    { id: 'sestihran', title: 'Šestihran', image: 'images/sestihran.png' },
     { id: 'valec', title: 'Válec', image: 'images/valec.png' },
     { id: 'jakl', title: 'Jakl', image: 'images/jakl.png' },
     { id: 'profil-l', title: 'Profil L', image: 'images/profil-l.png' },


### PR DESCRIPTION
## Summary
- update the Šestihran calculator tile to use the new PNG image asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de56a9d02083219e2b7cde30dfab61